### PR TITLE
Add support for history.pushState in router

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -1,0 +1,25 @@
+package detect
+
+import (
+	"github.com/gopherjs/gopherjs/js"
+)
+
+// IsClient returns true iff the code that is currently running is
+// compiled javascript code running in a browser with a global document
+// property.
+func IsClient() bool {
+	return IsJavascript() && js.Global.Get("document") != js.Undefined
+}
+
+// IsJavascript return true iff the code that is currently running
+// is compiled javascript code.
+func IsJavascript() bool {
+	return js.Global != nil
+}
+
+// IsServer returns true iff the code that is currently running is
+// pure go code. That is, if the code that is currently running has
+// not been compiled to javascript and is not running inside a browser.
+func IsServer() bool {
+	return !IsClient()
+}

--- a/karma/go/router_test.go
+++ b/karma/go/router_test.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
+	"github.com/go-humble/humble/router"
 	"github.com/gopherjs/gopherjs/js"
 	"github.com/rusco/qunit"
-	"github.com/soroushjp/humble/router"
 	"honnef.co/go/js/dom"
 	"strings"
 	"time"

--- a/karma/go/router_test.go
+++ b/karma/go/router_test.go
@@ -4,8 +4,15 @@ import (
 	"github.com/gopherjs/gopherjs/js"
 	"github.com/rusco/qunit"
 	"github.com/soroushjp/humble/router"
+	"strings"
 	"time"
 )
+
+// browserSupportsPushState will be true if the current browser
+// supports history.pushState and the onpopstate event.
+var browserSupportsPushState = (js.Global.Get("onpopstate") != js.Undefined) &&
+	(js.Global.Get("history") != js.Undefined) &&
+	(js.Global.Get("history").Get("pushState") != js.Undefined)
 
 type route struct {
 	path   string
@@ -29,12 +36,12 @@ func main() {
 		go func() {
 			select {
 			case gotRoute := <-routeChan:
-				assert.Equal(js.Global.Get("location").Get("pathname").String(), "/foo", "Path was not set correctly.")
+				checkPath(assert, "/foo")
 				assert.Equal(gotRoute.path, "/foo", "Triggered route had incorrect path.")
 				assert.DeepEqual(gotRoute.params, map[string]string{}, "Triggered route had incorrect params.")
 				done()
 			case <-time.After(200 * time.Millisecond):
-				// This is admiteddly very akward. But AFIAK there is no equivalent of t.Fail or t.Error
+				// This is admittedly very akward. But AFIAK there is no equivalent of t.Fail or t.Error
 				// in qunit.
 				assert.Ok(false, "Route was not triggered within 200 milliseconds")
 				assert.Ok(true, "")
@@ -43,4 +50,101 @@ func main() {
 			}
 		}()
 	})
+
+	qunit.Test("Route Params", func(assert qunit.QUnitAssert) {
+		qunit.Expect(3)
+		routeChan := make(chan route)
+		r := router.New()
+		r.HandleFunc("/foo/{param1}/{param2}", func(params map[string]string) {
+			routeChan <- route{
+				path:   "/foo/{param1}/{param2}",
+				params: params,
+			}
+		})
+		r.Start()
+		done := assert.Async()
+		go r.Navigate("/foo/bar/baz")
+		expectedParams := map[string]string{
+			"param1": "bar",
+			"param2": "baz",
+		}
+		go func() {
+			select {
+			case gotRoute := <-routeChan:
+				checkPath(assert, "/foo/bar/baz")
+				assert.Equal(gotRoute.path, "/foo/{param1}/{param2}", "Triggered route had incorrect path.")
+				assert.DeepEqual(gotRoute.params, expectedParams, "Triggered route had incorrect params.")
+				done()
+			case <-time.After(200 * time.Millisecond):
+				// This is admittedly very akward. But AFIAK there is no equivalent of t.Fail or t.Error
+				// in qunit.
+				assert.Ok(false, "Route was not triggered within 200 milliseconds")
+				assert.Ok(true, "")
+				assert.Ok(true, "")
+				done()
+			}
+		}()
+	})
+
+	qunit.Test("Back", func(assert qunit.QUnitAssert) {
+		qunit.Expect(3)
+		routeChan := make(chan route)
+		r := router.New()
+		r.HandleFunc("/foo", func(params map[string]string) {
+			routeChan <- route{
+				path:   "/foo",
+				params: params,
+			}
+		})
+		r.HandleFunc("/bar", func(params map[string]string) {
+			routeChan <- route{
+				path:   "/bar",
+				params: params,
+			}
+		})
+		r.Start()
+		done := assert.Async()
+		go func() {
+			// Navigate to /foo
+			r.Navigate("/foo")
+			// Wait for the "/foo" handler to be triggered
+			// once before continuing.
+			<-routeChan
+			// Navigate to /bar
+			r.Navigate("/bar")
+			// Wait for the "/bar" handler to be triggered
+			// once before continuing.
+			<-routeChan
+			// Navigate back to /foo, which should trigger the onpopstate listener
+			// or the onhashchange listener, depending on browser support.
+			js.Global.Get("history").Call("back")
+		}()
+		go func() {
+			select {
+			case gotRoute := <-routeChan:
+				checkPath(assert, "/foo")
+				assert.Equal(gotRoute.path, "/foo", "Triggered route had incorrect path.")
+				assert.DeepEqual(gotRoute.params, map[string]string{}, "Triggered route had incorrect params.")
+				done()
+			case <-time.After(200 * time.Millisecond):
+				// This is admittedly very akward. But AFIAK there is no equivalent of t.Fail or t.Error
+				// in qunit.
+				assert.Ok(false, "Route was not triggered within 200 milliseconds")
+				assert.Ok(true, "")
+				assert.Ok(true, "")
+				done()
+			}
+		}()
+	})
+}
+
+func checkPath(assert qunit.QUnitAssert, expected string) {
+	gotPath := ""
+	if browserSupportsPushState {
+		gotPath = js.Global.Get("location").Get("pathname").String()
+	} else {
+		hash := js.Global.Get("location").Get("hash").String()
+		gotPath = strings.SplitN(hash, "#", 2)[1]
+	}
+	assert.Equal(gotPath, expected, "Path was not set correctly.")
 }

--- a/karma/go/router_test.go
+++ b/karma/go/router_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"github.com/gopherjs/gopherjs/js"
 	"github.com/rusco/qunit"
 	"github.com/soroushjp/humble/router"
@@ -14,6 +15,7 @@ var browserSupportsPushState = (js.Global.Get("onpopstate") != js.Undefined) &&
 	(js.Global.Get("history") != js.Undefined) &&
 	(js.Global.Get("history").Get("pushState") != js.Undefined)
 
+// route is an internal representation of a route that has been triggered.
 type route struct {
 	path   string
 	params map[string]string
@@ -22,122 +24,91 @@ type route struct {
 func main() {
 	qunit.Test("Navigate", func(assert qunit.QUnitAssert) {
 		qunit.Expect(3)
-		routeChan := make(chan route)
 		r := router.New()
-		r.HandleFunc("/foo", func(params map[string]string) {
-			routeChan <- route{
-				path:   "/foo",
-				params: params,
-			}
-		})
+		// For this test and other similar tests in this file, we're going to
+		// create a channel called routeChan. Any router.Handlers that we set
+		// up are just going to send a route object through the routeChan. That
+		// way, we can recieve from the routeChan to detect when certain routes
+		// were triggered. And by extension, we can check that the expected route
+		// is triggered within a certain amount of time.
+		routeChan := make(chan route)
+		r.HandleFunc("/foo", newChanHandlerFunc("/foo", routeChan))
 		r.Start()
 		done := assert.Async()
 		go r.Navigate("/foo")
-		go func() {
-			select {
-			case gotRoute := <-routeChan:
-				checkPath(assert, "/foo")
-				assert.Equal(gotRoute.path, "/foo", "Triggered route had incorrect path.")
-				assert.DeepEqual(gotRoute.params, map[string]string{}, "Triggered route had incorrect params.")
-				done()
-			case <-time.After(200 * time.Millisecond):
-				// This is admittedly very akward. But AFIAK there is no equivalent of t.Fail or t.Error
-				// in qunit.
-				assert.Ok(false, "Route was not triggered within 200 milliseconds")
-				assert.Ok(true, "")
-				assert.Ok(true, "")
-				done()
-			}
-		}()
+		expectedRoute := route{
+			path:   "/foo",
+			params: map[string]string{},
+		}
+		go expectTriggeredRoute(assert, routeChan, "/foo", expectedRoute, done)
 	})
 
-	qunit.Test("Route Params", func(assert qunit.QUnitAssert) {
+	qunit.Test("Navigate with Params", func(assert qunit.QUnitAssert) {
 		qunit.Expect(3)
 		routeChan := make(chan route)
 		r := router.New()
-		r.HandleFunc("/foo/{param1}/{param2}", func(params map[string]string) {
-			routeChan <- route{
-				path:   "/foo/{param1}/{param2}",
-				params: params,
-			}
-		})
+		r.HandleFunc("/foo/{param1}/{param2}", newChanHandlerFunc("/foo/{param1}/{param2}", routeChan))
 		r.Start()
 		done := assert.Async()
 		go r.Navigate("/foo/bar/baz")
-		expectedParams := map[string]string{
-			"param1": "bar",
-			"param2": "baz",
+		expectedRoute := route{
+			path: "/foo/{param1}/{param2}",
+			params: map[string]string{
+				"param1": "bar",
+				"param2": "baz",
+			},
 		}
-		go func() {
-			select {
-			case gotRoute := <-routeChan:
-				checkPath(assert, "/foo/bar/baz")
-				assert.Equal(gotRoute.path, "/foo/{param1}/{param2}", "Triggered route had incorrect path.")
-				assert.DeepEqual(gotRoute.params, expectedParams, "Triggered route had incorrect params.")
-				done()
-			case <-time.After(200 * time.Millisecond):
-				// This is admittedly very akward. But AFIAK there is no equivalent of t.Fail or t.Error
-				// in qunit.
-				assert.Ok(false, "Route was not triggered within 200 milliseconds")
-				assert.Ok(true, "")
-				assert.Ok(true, "")
-				done()
-			}
-		}()
+		go expectTriggeredRoute(assert, routeChan, "/foo/bar/baz", expectedRoute, done)
 	})
 
-	qunit.Test("Back", func(assert qunit.QUnitAssert) {
+	qunit.Test("Navigate Back", func(assert qunit.QUnitAssert) {
 		qunit.Expect(3)
 		routeChan := make(chan route)
 		r := router.New()
-		r.HandleFunc("/foo", func(params map[string]string) {
-			routeChan <- route{
-				path:   "/foo",
-				params: params,
-			}
-		})
-		r.HandleFunc("/bar", func(params map[string]string) {
-			routeChan <- route{
-				path:   "/bar",
-				params: params,
-			}
-		})
+		r.HandleFunc("/foo", newChanHandlerFunc("/foo", routeChan))
+		r.HandleFunc("/bar", newChanHandlerFunc("/bar", routeChan))
 		r.Start()
 		done := assert.Async()
 		go func() {
-			// Navigate to /foo
+			// Navigate to "/foo"
 			r.Navigate("/foo")
 			// Wait for the "/foo" handler to be triggered
 			// once before continuing.
 			<-routeChan
-			// Navigate to /bar
+			// Navigate to "/bar"
 			r.Navigate("/bar")
 			// Wait for the "/bar" handler to be triggered
 			// once before continuing.
 			<-routeChan
-			// Navigate back to /foo, which should trigger the onpopstate listener
-			// or the onhashchange listener, depending on browser support.
+			// Navigate back to "/foo", which should trigger the onpopstate listener
+			// or the onhashchange listener, depending on browser support, and in turn
+			// trigger the corresponding router.Handler again.
 			js.Global.Get("history").Call("back")
 		}()
-		go func() {
-			select {
-			case gotRoute := <-routeChan:
-				checkPath(assert, "/foo")
-				assert.Equal(gotRoute.path, "/foo", "Triggered route had incorrect path.")
-				assert.DeepEqual(gotRoute.params, map[string]string{}, "Triggered route had incorrect params.")
-				done()
-			case <-time.After(200 * time.Millisecond):
-				// This is admittedly very akward. But AFIAK there is no equivalent of t.Fail or t.Error
-				// in qunit.
-				assert.Ok(false, "Route was not triggered within 200 milliseconds")
-				assert.Ok(true, "")
-				assert.Ok(true, "")
-				done()
-			}
-		}()
+		expectedRoute := route{
+			path:   "/foo",
+			params: map[string]string{},
+		}
+		go expectTriggeredRoute(assert, routeChan, "/foo", expectedRoute, done)
 	})
 }
 
+// newChanHandlerFunc will create and return a router.Handler which, when run,
+// will send the route that was triggered (along with its params) through the
+// given routeChan. This serves as an easy way for us to test which routes were
+// triggered and what params were provided.
+func newChanHandlerFunc(path string, routeChan chan route) router.Handler {
+	return func(params map[string]string) {
+		routeChan <- route{
+			path:   path,
+			params: params,
+		}
+	}
+}
+
+// checkPath checks that the browser is currently at the expected path. It
+// knows whether or not to check the hash or the pathname based on browser
+// support.
 func checkPath(assert qunit.QUnitAssert, expected string) {
 	gotPath := ""
 	if browserSupportsPushState {
@@ -147,4 +118,25 @@ func checkPath(assert qunit.QUnitAssert, expected string) {
 		gotPath = strings.SplitN(hash, "#", 2)[1]
 	}
 	assert.Equal(gotPath, expected, "Path was not set correctly.")
+}
+
+// expectTriggeredRoute will first wait to receive from routeChan. When it receives, it checks the route
+// object to make sure it matches expectedRoute. It also checks window.location to make sure that the
+// browser actually navigated to expectedPath. If the route is not triggered within 200 milliseconds, the
+// check will fail. The function will call done (which should be from assert.Async()) when it is done.
+func expectTriggeredRoute(assert qunit.QUnitAssert, routeChan chan route, expectedPath string, expectedRoute route, done func()) {
+	select {
+	case gotRoute := <-routeChan:
+		checkPath(assert, expectedPath)
+		assert.Equal(gotRoute.path, expectedRoute.path, "Triggered route had incorrect path.")
+		assert.DeepEqual(gotRoute.params, expectedRoute.params, "Triggered route had incorrect params.")
+		done()
+	case <-time.After(200 * time.Millisecond):
+		// This is admittedly very akward. But AFIAK there is no equivalent of t.Fail or t.Error
+		// in qunit.
+		assert.Ok(false, fmt.Sprintf("Route %s was not triggered within 200 milliseconds", expectedRoute.path))
+		assert.Ok(true, "")
+		assert.Ok(true, "")
+		done()
+	}
 }

--- a/karma/go/router_test.go
+++ b/karma/go/router_test.go
@@ -34,6 +34,7 @@ func main() {
 		routeChan := make(chan route)
 		r.HandleFunc("/foo", newChanHandlerFunc("/foo", routeChan))
 		r.Start()
+		defer r.Stop()
 		done := assert.Async()
 		go r.Navigate("/foo")
 		expectedRoute := route{
@@ -45,10 +46,11 @@ func main() {
 
 	qunit.Test("Navigate with Params", func(assert qunit.QUnitAssert) {
 		qunit.Expect(3)
-		routeChan := make(chan route)
 		r := router.New()
+		routeChan := make(chan route)
 		r.HandleFunc("/foo/{param1}/{param2}", newChanHandlerFunc("/foo/{param1}/{param2}", routeChan))
 		r.Start()
+		defer r.Stop()
 		done := assert.Async()
 		go r.Navigate("/foo/bar/baz")
 		expectedRoute := route{
@@ -63,11 +65,12 @@ func main() {
 
 	qunit.Test("Navigate Back", func(assert qunit.QUnitAssert) {
 		qunit.Expect(3)
-		routeChan := make(chan route)
 		r := router.New()
+		routeChan := make(chan route)
 		r.HandleFunc("/foo", newChanHandlerFunc("/foo", routeChan))
 		r.HandleFunc("/bar", newChanHandlerFunc("/bar", routeChan))
 		r.Start()
+		defer r.Stop()
 		done := assert.Async()
 		go func() {
 			// Navigate to "/foo"
@@ -83,7 +86,7 @@ func main() {
 			// Navigate back to "/foo", which should trigger the onpopstate listener
 			// or the onhashchange listener, depending on browser support, and in turn
 			// trigger the corresponding router.Handler again.
-			js.Global.Get("history").Call("back")
+			r.Back()
 		}()
 		expectedRoute := route{
 			path:   "/foo",

--- a/karma/go/router_test.go
+++ b/karma/go/router_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"github.com/gopherjs/gopherjs/js"
+	"github.com/rusco/qunit"
+	"github.com/soroushjp/humble/router"
+	"time"
+)
+
+type route struct {
+	path   string
+	params map[string]string
+}
+
+func main() {
+	qunit.Test("Navigate", func(assert qunit.QUnitAssert) {
+		qunit.Expect(3)
+		routeChan := make(chan route)
+		r := router.New()
+		r.HandleFunc("/foo", func(params map[string]string) {
+			routeChan <- route{
+				path:   "/foo",
+				params: params,
+			}
+		})
+		r.Start()
+		done := assert.Async()
+		go r.Navigate("/foo")
+		go func() {
+			select {
+			case gotRoute := <-routeChan:
+				assert.Equal(js.Global.Get("location").Get("pathname").String(), "/foo", "Path was not set correctly.")
+				assert.Equal(gotRoute.path, "/foo", "Triggered route had incorrect path.")
+				assert.DeepEqual(gotRoute.params, map[string]string{}, "Triggered route had incorrect params.")
+				done()
+			case <-time.After(200 * time.Millisecond):
+				// This is admiteddly very akward. But AFIAK there is no equivalent of t.Fail or t.Error
+				// in qunit.
+				assert.Ok(false, "Route was not triggered within 200 milliseconds")
+				assert.Ok(true, "")
+				assert.Ok(true, "")
+				done()
+			}
+		}()
+	})
+}

--- a/router/router.go
+++ b/router/router.go
@@ -13,7 +13,7 @@ var browserSupportsPushState = (js.Global.Get("onpopstate") != js.Undefined) &&
 	(js.Global.Get("history") != js.Undefined) &&
 	(js.Global.Get("history").Get("pushState") != js.Undefined)
 
-// Router is responsible for handling routes. If window.pushState is
+// Router is responsible for handling routes. If history.pushState is
 // supported, it uses that to navigate from page to page and will listen
 // to the "onpopstate" event. Otherwise, it sets the hash component of the
 // url and listens to changes via the "onhashchange" event.
@@ -39,7 +39,7 @@ type route struct {
 }
 
 // HandleFunc will cause the router to call f whenever window.location.pathname
-// (or window.location.hash, if window.pushState is not supported) matches path.
+// (or window.location.hash, if history.pushState is not supported) matches path.
 // path can contain any number of parameters which are denoted with curly brackets.
 // So, for example, a path argument of "users/{id}" will be triggered when the user
 // visits users/123 and will call the handler function with params["id"] = "123".

--- a/router/router.go
+++ b/router/router.go
@@ -11,19 +11,24 @@ import (
 var (
 	// browserSupportsPushState will be true if the current browser
 	// supports history.pushState and the onpopstate event.
-	browserSupportsPushState = (js.Global.Get("onpopstate") != js.Undefined) &&
-		(js.Global.Get("history") != js.Undefined) &&
-		(js.Global.Get("history").Get("pushState") != js.Undefined)
-	document dom.HTMLDocument
+	browserSupportsPushState bool
+	document                 dom.HTMLDocument
 )
 
+func isClient() bool {
+	return js.Global != nil && js.Global.Get("document") != js.Undefined
+}
+
 func init() {
-	if js.Global != nil {
+	if isClient() {
 		var ok bool
 		document, ok = dom.GetWindow().Document().(dom.HTMLDocument)
 		if !ok {
 			panic("Could not convert document to dom.HTMLDocument")
 		}
+		browserSupportsPushState = (js.Global.Get("onpopstate") != js.Undefined) &&
+			(js.Global.Get("history") != js.Undefined) &&
+			(js.Global.Get("history").Get("pushState") != js.Undefined)
 	}
 }
 

--- a/router/router.go
+++ b/router/router.go
@@ -2,8 +2,9 @@ package router
 
 import (
 	"github.com/gopherjs/gopherjs/js"
-	"honnef.co/go/js/console"
+	"github.com/soroushjp/humble/detect"
 	"honnef.co/go/js/dom"
+	"log"
 	"regexp"
 	"strings"
 )
@@ -15,12 +16,8 @@ var (
 	document                 dom.HTMLDocument
 )
 
-func isClient() bool {
-	return js.Global != nil && js.Global.Get("document") != js.Undefined
-}
-
 func init() {
-	if isClient() {
+	if detect.IsClient() {
 		var ok bool
 		document, ok = dom.GetWindow().Document().(dom.HTMLDocument)
 		if !ok {
@@ -212,7 +209,7 @@ func (r *Router) pathChanged(path string) {
 	bestRoute, tokens := r.findBestRoute(path)
 	// If no routes match, we throw console error and no handlers are called
 	if bestRoute == nil {
-		console.Error("Could not find route to match: " + path)
+		log.Fatal("Could not find route to match: " + path)
 		return
 	}
 	// Make the params map and pass it to the handler

--- a/router/router.go
+++ b/router/router.go
@@ -86,9 +86,10 @@ func (r *Router) Start() {
 // and update window.location accordingly. If the browser supports
 // history.pushState, that will be used. Otherwise, Navigate will
 // set the hash component of window.location to the given path.
-func Navigate(path string) {
+func (r *Router) Navigate(path string) {
 	if browserSupportsPushState {
 		pushState(path)
+		r.pathChanged(path)
 	} else {
 		setHash(path)
 	}

--- a/router/router.go
+++ b/router/router.go
@@ -145,7 +145,13 @@ func (r *Router) Back() {
 
 // InterceptLinks intercepts click events on links of the form <a href="/foo"></a>
 // and calls router.Navigate("/foo") instead, which triggers the appropriate Handler
-// instead of requesting a new page from the server.
+// instead of requesting a new page from the server. Since InterceptLinks works by
+// setting event listeners in the DOM, you must call this function whenever the DOM
+// is changed. Alternatively, you can set r.ShouldInterceptLinks to true, which will
+// trigger this function whenever Start, Navigate, or Back are called, or when the
+// onpopstate event is triggered. Even with r.ShouldInterceptLinks set to true, you
+// may still need to call this function if you change the DOM manually without
+// triggering a route.
 func (r *Router) InterceptLinks() {
 	for _, link := range document.Links() {
 		href := link.GetAttribute("href")
@@ -172,6 +178,9 @@ func (r *Router) InterceptLinks() {
 	}
 }
 
+// interceptLink is intended to be used as a callback function. It stops
+// the default behavior of event and instead calls r.Navigate, passing through
+// the link's href property.
 func (r *Router) interceptLink(event dom.Event) {
 	event.PreventDefault()
 	href := event.CurrentTarget().GetAttribute("href")

--- a/router/router.go
+++ b/router/router.go
@@ -131,26 +131,27 @@ func (r *Router) Back() {
 // instead of requesting a new page from the server.
 func (r *Router) InterceptLinks() {
 	for _, link := range document.Links() {
-		link.AddEventListener("click", true, func(event dom.Event) {
-			href := link.GetAttribute("href")
-			switch {
-			case href == "":
-				return
-			case strings.HasPrefix(href, "http://"), strings.HasPrefix(href, "https://"), strings.HasPrefix(href, "//"):
-				// These are external links and should behave normally.
-				return
-			case strings.HasPrefix(href, "#"):
-				// These are anchor links and should behave normally.
-				// Recall that even when we are using the hash trick, href
-				// attributes should be relative paths without the "#" and
-				// router will handle them appropriately.
-				return
-			case strings.HasPrefix(href, "/"):
-				// These are relative links. The kind that we want to intercept.
+		href := link.GetAttribute("href")
+		switch {
+		case href == "":
+			return
+		case strings.HasPrefix(href, "http://"), strings.HasPrefix(href, "https://"), strings.HasPrefix(href, "//"):
+			// These are external links and should behave normally.
+			return
+		case strings.HasPrefix(href, "#"):
+			// These are anchor links and should behave normally.
+			// Recall that even when we are using the hash trick, href
+			// attributes should be relative paths without the "#" and
+			// router will handle them appropriately.
+			return
+		case strings.HasPrefix(href, "/"):
+			// These are relative links. The kind that we want to intercept.
+			link.AddEventListener("click", true, func(event dom.Event) {
 				event.PreventDefault()
 				go r.Navigate(href)
-			}
-		})
+			})
+		}
+
 	}
 }
 

--- a/router/router.go
+++ b/router/router.go
@@ -241,14 +241,15 @@ func (r Router) findBestRoute(path string) (bestRoute *route, tokens []string) {
 	return bestRoute, tokens
 }
 
-// removeEmptyStrings removes any empty strings from a
-func removeEmptyStrings(a []string) []string {
-	for i, s := range a {
-		if s == "" {
-			a = append(a[:i], a[i+1:]...)
+// removeEmptyStrings removes any empty strings from strings
+func removeEmptyStrings(strings []string) []string {
+	result := []string{}
+	for _, s := range strings {
+		if s != "" {
+			result = append(result, s)
 		}
 	}
-	return a
+	return result
 }
 
 // watchHash listens to the onhashchange event and calls r.pathChanged when

--- a/router/router.go
+++ b/router/router.go
@@ -82,6 +82,16 @@ func (r *Router) Start() {
 	}
 }
 
+// Stop causes the router to stop listening for changes, and therefore
+// the router will not trigger any more router.Handler functions.
+func (r *Router) Stop() {
+	if browserSupportsPushState {
+		js.Global.Set("onpopstate", nil)
+	} else {
+		js.Global.Set("onhashchange", nil)
+	}
+}
+
 // Navigate will trigger the handler associated with the given path
 // and update window.location accordingly. If the browser supports
 // history.pushState, that will be used. Otherwise, Navigate will
@@ -93,6 +103,13 @@ func (r *Router) Navigate(path string) {
 	} else {
 		setHash(path)
 	}
+}
+
+// Back will cause the browser to go back to the previous page.
+// It has the same effect as the user pressing the back button,
+// and is just a wrapper around history.back()
+func (r *Router) Back() {
+	js.Global.Get("location").Call("back")
 }
 
 // setInitialHash will set hash to / if there is currently no hash.

--- a/router/router.go
+++ b/router/router.go
@@ -123,7 +123,7 @@ func (r *Router) Navigate(path string) {
 // It has the same effect as the user pressing the back button,
 // and is just a wrapper around history.back()
 func (r *Router) Back() {
-	js.Global.Get("location").Call("back")
+	js.Global.Get("history").Call("back")
 }
 
 // InterceptLinks intercepts click events on links of the form <a href="/foo"></a>

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -99,3 +99,37 @@ func generateTestHandler(path string, gotPath *string, gotParams *map[string]str
 		*gotParams = params
 	}
 }
+
+func TestRemoveEmptyStrings(t *testing.T) {
+	testCases := []struct {
+		input    []string
+		expected []string
+	}{
+		{
+			input:    []string{"a", "b", "c"},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			input:    []string{"a", "b", ""},
+			expected: []string{"a", "b"},
+		},
+		{
+			input:    []string{"a", "", "c"},
+			expected: []string{"a", "c"},
+		},
+		{
+			input:    []string{"", "b", "c"},
+			expected: []string{"b", "c"},
+		},
+		{
+			input:    []string{"", "", ""},
+			expected: []string{},
+		},
+	}
+	for i, tc := range testCases {
+		got := removeEmptyStrings(tc.input)
+		if !reflect.DeepEqual(got, tc.expected) {
+			t.Errorf("removeEmptyStrings failed for test case %d\nExpected: %v\nBut got  %v", i, tc.expected, got)
+		}
+	}
+}

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -5,48 +5,48 @@ import (
 	"testing"
 )
 
-// routeTestCases is format for test case. Each test case takes possible route paths, the URL hash provided
+// routeTestCases is format for test case. Each test case takes possible route paths, the URL path provided
 // and the expected route path and query parameters.
 var routeTestCases = []struct {
 	paths          []string
-	hash           string
+	path           string
 	expectedPath   string
 	expectedParams map[string]string
 }{
 	// Test route to /
 	{
 		paths:          []string{"/home", "/about", "/"},
-		hash:           "#/",
+		path:           "/",
 		expectedPath:   "/",
 		expectedParams: nil,
 	},
 	// Test basic literal
 	{
 		paths:          []string{"/home", "/about"},
-		hash:           "#/home",
+		path:           "/home",
 		expectedPath:   "/home",
 		expectedParams: nil,
 	},
-	// Test trailing slash in hash
+	// Test trailing slash in path
 	{
 		paths:          []string{"/home", "/about"},
-		hash:           "#/about/",
+		path:           "/about/",
 		expectedPath:   "/about",
 		expectedParams: nil,
 	},
 	// Test query param
 	{
 		paths:        []string{"/home", "/home/{homeId}", "/about"},
-		hash:         "#/home/55",
+		path:         "/home/55",
 		expectedPath: "/home/{homeId}",
 		expectedParams: map[string]string{
 			"homeId": "55",
 		},
 	},
-	// Test trailing slash after query param in hash
+	// Test trailing slash after query param in path
 	{
 		paths:        []string{"/home", "/about", "/about/{aboutId}"},
-		hash:         "#/about/55/",
+		path:         "/about/55/",
 		expectedPath: "/about/{aboutId}",
 		expectedParams: map[string]string{
 			"aboutId": "55",
@@ -55,7 +55,7 @@ var routeTestCases = []struct {
 	// Test multiple query params
 	{
 		paths:        []string{"/home", "/home/{homeId}", "/about", "/home/{homeId}/image/{imageSize}/{imageType}/jpg"},
-		hash:         "#/home/55/image/800x600/panoramic/jpg",
+		path:         "/home/55/image/800x600/panoramic/jpg",
 		expectedPath: "/home/{homeId}/image/{imageSize}/{imageType}/jpg",
 		expectedParams: map[string]string{
 			"homeId":    "55",
@@ -66,7 +66,7 @@ var routeTestCases = []struct {
 	// Test tie breaker
 	{
 		paths:          []string{"/home/all", "/home/{homeId}", "/about"},
-		hash:           "#/home/all",
+		path:           "/home/all",
 		expectedPath:   "/home/all",
 		expectedParams: nil,
 	},
@@ -81,13 +81,13 @@ func TestRouter(t *testing.T) {
 			handler := generateTestHandler(path, &gotPath, &gotParams)
 			r.HandleFunc(path, handler)
 		}
-		r.hashChanged(tc.hash)
+		r.pathChanged(tc.path)
 		if gotPath != tc.expectedPath {
-			t.Errorf("Failed for hash=%s. Expected path: %s, Got path: %s", tc.hash, tc.expectedPath, gotPath)
+			t.Errorf("Failed for path=%s. Expected path: %s, Got path: %s", tc.path, tc.expectedPath, gotPath)
 		}
 		if tc.expectedParams != nil {
 			if !reflect.DeepEqual(gotParams, tc.expectedParams) {
-				t.Errorf("Failed for hash=%s. Expected params: %s, Got params: %s", tc.hash, tc.expectedParams, gotParams)
+				t.Errorf("Failed for path=%s. Expected params: %s, Got params: %s", tc.path, tc.expectedParams, gotParams)
 			}
 		}
 	}


### PR DESCRIPTION
I've added support for `history.pushState` and the `onpopstate` event for browsers that support it. For browser that don't support it, router falls back to the old implementation. What this means is that we no longer need to use the `window.location.hash` trick on modern browsers. It also makes hybrid rendering much more realistic, since the same url can be used for client-side or server-side templates.

I also added a few other smaller features:
- `router.Stop` does what it sounds like it does. Routes will no longer be triggered.
- `router.Navigate` navigates to the given path. Behind the scenes it uses the hash trick if needed.
- `router.Back` has the same effect as the user pressing the back button.

In addition, I created karma tests for the router. All of them pass on OS X with Chrome, Safari, and Firefox.

I still intend to add one more feature before this is merged: an `InterceptLinks` function which will intercept click events on links of the form `<a href="/foo"></a>` and call `router.Navigate("/foo")` instead. That way we can trigger the corresponding route (and probably render a page client-side) instead of sending a request to the server for a new page.
